### PR TITLE
Support dark mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,6 @@ typings/
 
 # next.js build output
 .next
+
+# Local Netlify folder
+.netlify

--- a/css/layout.css
+++ b/css/layout.css
@@ -3,12 +3,7 @@
 @import url("./sidebar.css");
 @import url("./main.css");
 @import url("./footer.css");
-
-body.grid {
-	grid-template-areas: 'header header header' 'nav nav nav' '. main sidebar' 'footer footer footer';
-	grid-template-rows: calc(100vh - var(--nav-height)) var(--nav-height) minmax(600px, auto) auto;
-	grid-template-columns: 1fr minmax(350px, 1000px) 1fr;
-}
+@import url("https://cdn.kernvalley.us/css/core-css/layout/default/index.css");
 
 .content {
 	margin: 1.2em;

--- a/css/vars.css
+++ b/css/vars.css
@@ -1,41 +1,8 @@
+@import url("https://cdn.kernvalley.us/css/core-css/theme/default/index.css");
+
 :root {
-	--default-color: #343434;
-	--primary-color: #fafafa;
-	--accent-color: #528ff9;
-	--contrast-color: #4c4c4c;
-	--alt-color: #fefefe;
-	--main-font: "Roboto";
-	--line-height: 1.3;
-	--default-cursor: auto;
-	--link-color: inherit;
-
-	--desktop-rem: 1.3vmax;
-	--tablet-rem: 1.6vmax;
-	--mobile-rem: 20px;
-
-	--button-background: var(--accent-color);
-	--button-color: var(--alt-color);
-	--button-border: none;
-	--button-border-radius: 0.15rem;
-	--button-padding: 0.4rem;
-
-	--button-active-background: #1048a1;
-	--button-active-color: var(--button-color);
-	--button-active-border: var(--button-border);
-
-	--button-disabled-background: #787878;
-	--button-disabled-color: #4e4e4e;
-	--button-disabled-border: var(--button-border);
-
-	--button-accept-background: #1FA214;
-	--button-accept-active-background: #157a0c;
-
-	--button-reject-background: #B31414;
-	--button-reject-active-background: #7a0c0c;
-
-	--dialog-border: none;
-
 	--nav-height: 2.7rem;
 	--header-height: 0;
 	--footer-height: auto;
+	--contrast-color: var(--primary-color-dark);
 }

--- a/netlify.toml
+++ b/netlify.toml
@@ -33,6 +33,7 @@
       manifest-src 'self';
       form-action 'self';
       reflected-xss block;
+      report-uri https://api.kernvalley.us/Errors/CSP/
       block-all-mixed-content;
       upgrade-insecure-requests;
       disown-opener;'''

--- a/sw-config.js
+++ b/sw-config.js
@@ -1,3 +1,4 @@
+/* eslint no-unused-vars: 0 */
 const config = {
 	version: location.hostname === 'localhost' ? new Date().toISOString() : '1.0.0',
 	stale: [
@@ -38,6 +39,12 @@ const config = {
 		'https://cdn.kernvalley.us/css/core-css/utility.css',
 		'https://cdn.kernvalley.us/css/core-css/fonts.css',
 		'https://cdn.kernvalley.us/css/core-css/animations.css',
+		'https://cdn.kernvalley.us/css/core-css/theme/base.css',
+		'https://cdn.kernvalley.us/css/core-css/theme/default/index.css',
+		'https://cdn.kernvalley.us/css/core-css/theme/default/light.css',
+		'https://cdn.kernvalley.us/css/core-css/theme/default/dark.css',
+		'https://cdn.kernvalley.us/css/core-css/layout/shared.css',
+		'https://cdn.kernvalley.us/css/core-css/layout/default/index.css',
 		'https://cdn.kernvalley.us/css/normalize/normalize.css',
 		'https://cdn.kernvalley.us/css/animate.css/animate.css',
 		'/img/icons.svg',


### PR DESCRIPTION
Update `core-css` with support for dark mode.

Use default theme & layout from CDN.KernValley.us.

Ignore Netlify site id in `.gitignore`

![screenshot](https://i.imgur.com/9qjlgmb.png)

