### PR TITLE
Update eslint config for `switch` indentation

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,10 @@
     "rules": {
         "indent": [
             2,
-            "tab"
+            "tab",
+            {
+              "SwitchCase": 1
+            }
         ],
         "quotes": [
             2,
@@ -27,6 +30,5 @@
         "no-prototype-builtins": 0,
         "async-await/space-after-async": 2,
         "async-await/space-after-await": 2
-    },
-    "globals": {}
+    }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [v1.0.4] - 2020-07-07
+
+### Updated
+- eslint now indents on each `case` for a `switch
+
 ## [v1.0.3] - 2020-07-16
 
 ### Changed


### PR DESCRIPTION
### Updated
- eslint now indents on each `case` for a `switch`