### PR TITLE
Add missing classes to share button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Add missing classes to properly style share button
+
 ## [v1.0.6] - 2020-08-21
 
 ### Added

--- a/index.html
+++ b/index.html
@@ -166,7 +166,7 @@
 				</github-user>
 			</div>
 		</footer>
-		<button type="button" is="share-button" class="round shadow fixed z-4" aria-label="Share">
+		<button type="button" is="share-button" class="btn btn-primary round shadow fixed z-4" aria-label="Share">
 			<svg class="current-color icon" aria-hidden="true" aria-label="icon" aria-role="img">
 				<use xlink:href="/img/icons.svg#public-share"></use>
 			</svg>


### PR DESCRIPTION
Styling of buttons is no longer the default, so add missing classes to apply styles