### PR TITLE
Update to force usage of LF for EOL

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
 # Auto detect text files and perform LF normalization
-* text=auto
+* text=auto eol=lf
 # Custom for Visual Studio
 *.cs     diff=csharp
 # For GPG/PGP encrypted files

--- a/index.html
+++ b/index.html
@@ -3,7 +3,8 @@
 	<head>
 		<base href="/" />
 		<meta charset="utf-8" />
-		<meta name="viewport" content="width=device-width" />
+		<meta name="viewport" content="width=device-width,viewport-fit=cover" />
+		<meta name="color-scheme" content="dark light" />
 		<meta name="robots" content="follow,index" />
 		<meta name="description" content="" />
 		<meta itemprop="description" content="" />


### PR DESCRIPTION
Also adds `<meta name="color-scheme" content="dark light" />`